### PR TITLE
Pass source_name to formatter when formatting metric objects

### DIFF
--- a/datahub_metrics_ingest/FormatterInterface.py
+++ b/datahub_metrics_ingest/FormatterInterface.py
@@ -7,5 +7,5 @@ class FormatterInterface(ABC):
         super().__init__()
 
     @abstractmethod
-    def get_data_objects(self, metric) -> [DHMetric]:
+    def get_data_objects(self, metric, source_name) -> [DHMetric]:
         raise NotImplementedError

--- a/datahub_metrics_ingest/NTLMetricFormatter.py
+++ b/datahub_metrics_ingest/NTLMetricFormatter.py
@@ -8,7 +8,7 @@ class NTLMetricFormatter(FormatterInterface):
     def __init__(self):
         pass    #intentionally empty constructor
 
-    def get_data_objects(self, metrics) -> [DHMetric]:
+    def get_data_objects(self, metrics, source_name = 'ntl') -> [DHMetric]:
 
         result = []
 
@@ -19,7 +19,7 @@ class NTLMetricFormatter(FormatterInterface):
             dm = DHMetric()
             dm.timestamp = dateutil.parser.parse(metric['Month']).strftime('%Y-%m-01')
             dm.granularity = 'monthly'
-            dm.dh_source_name = 'ntl'
+            dm.dh_source_name = source_name
             dm.dh_id = f"{dm.dh_source_name}-dot:{metric['Page'].split('/')[-1]}"
             dm.user_segment = None
             dm.access_type = 'page view'

--- a/datahub_metrics_ingest/SocrataMetricFormatter.py
+++ b/datahub_metrics_ingest/SocrataMetricFormatter.py
@@ -7,7 +7,7 @@ class SocrataMetricFormatter(FormatterInterface):
     def __init__(self):
         pass  #intentionally empty constructor
 
-    def get_data_objects(self, metrics) -> [DHMetric]:
+    def get_data_objects(self, metrics, source_name) -> [DHMetric]:
         # aggregate hourly metric to daily metric
         daily_metric_dict = {}
         for m in metrics:
@@ -25,7 +25,7 @@ class SocrataMetricFormatter(FormatterInterface):
             dm = DHMetric()
             dm.timestamp = date
             dm.granularity = 'daily'
-            dm.dh_source_name = 'scgc'
+            dm.dh_source_name = source_name
             dm.dh_id = f'{dm.dh_source_name}-{asset_uid}'
             dm.user_segment = user_segment
             dm.access_type = access_type

--- a/tests/test_SocrataMetricFormatter.py
+++ b/tests/test_SocrataMetricFormatter.py
@@ -11,7 +11,7 @@ class TestSocrataMetricFormatter(unittest.TestCase):
     def test_getSocrataMetricObjects(self):
         test_results = UtilsTest().get_scgc_metric_mock_data()
         test_socrata_metric_formatter = SocrataMetricFormatter()
-        formatted_results = test_socrata_metric_formatter.get_data_objects(test_results)
+        formatted_results = test_socrata_metric_formatter.get_data_objects(test_results, 'scgc')
 
         self.assertEqual(len(formatted_results), 6, 'Metrics not aggregated properly')
         self.assertEqual(
@@ -23,7 +23,7 @@ class TestSocrataMetricFormatter(unittest.TestCase):
     def test_validate_fields_dtg(self):
         test_input = UtilsTest().get_scgc_metric_mock_data()
         test_socrata_metric_formatter = SocrataMetricFormatter()
-        formatted_results = test_socrata_metric_formatter.get_data_objects(test_input)
+        formatted_results = test_socrata_metric_formatter.get_data_objects(test_input[:1], 'scgc')
         out_rec = formatted_results[0]
 
         self.assertEqual(type(dateutil.parser.parse(out_rec.timestamp)), datetime, 'Invalid timestamp')
@@ -33,3 +33,8 @@ class TestSocrataMetricFormatter(unittest.TestCase):
         self.assertTrue(re.match(r'scgc-[a-z0-9]{4}-[a-z0-9]{4}', out_rec.dh_id), 'Invalid dh_id')
         self.assertIsNot(out_rec.user_segment, None, 'Invalid user_segment')
         self.assertIsNot(out_rec.access_type, None, 'Invalid access_type')
+
+        formatted_results_dtg = test_socrata_metric_formatter.get_data_objects(test_input[1:], 'dtg')
+        out_rec_dtg = formatted_results_dtg[0]
+
+        self.assertEqual(out_rec_dtg.dh_source_name, 'dtg', 'Invalid dh_source_name')


### PR DESCRIPTION
Part of [RDAODTD-2389](https://usdotjpoode.atlassian.net/browse/RDAODTD-2389).
This PR passes a `source_name` variable when formatting metric objects, instead of using a default value for the `dh_source_name` field for each formatter. This will allow one formatter to be used for multiple sources (e.g. the Socrata Formatter can be used for metrics from DTG and SCGC.
